### PR TITLE
Separate logic-solvable and general benchmark scripts

### DIFF
--- a/scripts/run_general.py
+++ b/scripts/run_general.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Run benchmarks on general Sudoku instances."""
+
+import argparse
+from pathlib import Path
+
+from bench_utils import default_binary, maybe_write_xlsx, run_general, write_csv
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description='Run Sudoku ACO experiments on general instances and export results.'
+    )
+    ap.add_argument('--binary', default=default_binary(), help='Path to solver binary (default: auto-detect)')
+    ap.add_argument('--instances', default='instances', help='Instances root folder (default: instances)')
+    ap.add_argument('--timeout', type=int, default=10, help='Per-run timeout seconds (default: 10)')
+    ap.add_argument('--algs', default='0,1,2', help='Comma-separated list of alg ids to run (default: 0,1,2)')
+    ap.add_argument('--outdir', default='scripts', help='Output directory (default: scripts)')
+    ap.add_argument('--verbose', action='store_true', help='Print progress while running instances')
+    args = ap.parse_args()
+
+    binary = args.binary
+    algs = [int(x.strip()) for x in args.algs.split(',') if x.strip() != '']
+    gen_dir = Path(args.instances) / 'general'
+
+    def vlog(*a, **k):
+        if args.verbose:
+            print(*a, **k, flush=True)
+
+    headers, rows = run_general(algs, gen_dir, binary, args.timeout, vlog)
+    outdir = Path(args.outdir)
+    write_csv(outdir / 'general.csv', headers, rows)
+    print(f"Wrote: {outdir / 'general.csv'}")
+
+    if maybe_write_xlsx(outdir / 'general.xlsx', [('general', headers, rows)]):
+        print(f"Also tried to write Excel workbook to: {outdir / 'general.xlsx'} (if Excel lib was available)")
+
+
+if __name__ == '__main__':
+    main()
+

--- a/scripts/run_logic.py
+++ b/scripts/run_logic.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Run benchmarks on logic-solvable Sudoku instances."""
+
+import argparse
+from pathlib import Path
+
+from bench_utils import (
+    default_binary,
+    maybe_write_xlsx,
+    run_logic,
+    write_csv,
+)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description='Run Sudoku ACO experiments on logic-solvable instances and export results.'
+    )
+    ap.add_argument('--binary', default=default_binary(), help='Path to solver binary (default: auto-detect)')
+    ap.add_argument('--instances', default='instances', help='Instances root folder (default: instances)')
+    ap.add_argument('--timeout', type=int, default=10, help='Per-run timeout seconds (default: 10)')
+    ap.add_argument('--algs', default='0,1,2', help='Comma-separated list of alg ids to run (default: 0,1,2)')
+    ap.add_argument('--reps_logic', type=int, default=100, help='Repetitions per instance (default: 100)')
+    ap.add_argument('--outdir', default='scripts', help='Output directory (default: scripts)')
+    ap.add_argument('--verbose', action='store_true', help='Print progress while running instances')
+    args = ap.parse_args()
+
+    binary = args.binary
+    algs = [int(x.strip()) for x in args.algs.split(',') if x.strip() != '']
+    logic_dir = Path(args.instances) / 'logic-solvable'
+
+    def vlog(*a, **k):
+        if args.verbose:
+            print(*a, **k, flush=True)
+
+    headers, rows = run_logic(algs, logic_dir, binary, args.timeout, args.reps_logic, vlog)
+    outdir = Path(args.outdir)
+    write_csv(outdir / 'logic-solvable.csv', headers, rows)
+    print(f"Wrote: {outdir / 'logic-solvable.csv'}")
+
+    if maybe_write_xlsx(outdir / 'logic-solvable.xlsx', [('logic-solvable', headers, rows)]):
+        print(
+            f"Also tried to write Excel workbook to: {outdir / 'logic-solvable.xlsx'} (if Excel lib was available)"
+        )
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
## Summary
- Factor shared benchmarking helpers into `bench_utils`
- Add `run_logic.py` to execute logic-solvable instance benchmarks and write `logic-solvable.csv`
- Add `run_general.py` for general instance benchmarks writing `general.csv`

## Testing
- `python -m py_compile scripts/bench_utils.py scripts/run_logic.py scripts/run_general.py`
- `python scripts/run_logic.py --help`
- `python scripts/run_general.py --help`


------
https://chatgpt.com/codex/tasks/task_b_68bd0effc58c83218162ae0bb9c5ad2c